### PR TITLE
fix `Indent#String()` support golint

### DIFF
--- a/xmlgen.go
+++ b/xmlgen.go
@@ -34,6 +34,43 @@ import (
 	"unicode"
 )
 
+// commonInitialisms is a set of common initialisms.
+// Only add entries that are highly unlikely to be non-initialisms.
+// For instance, "ID" is fine (Freudian code is rare), but "AND" is not.
+var commonInitialisms = map[string]bool{
+	"API":   true,
+	"ASCII": true,
+	"CPU":   true,
+	"CSS":   true,
+	"DNS":   true,
+	"EOF":   true,
+	"GUID":  true,
+	"HTML":  true,
+	"HTTP":  true,
+	"HTTPS": true,
+	"ID":    true,
+	"IP":    true,
+	"JSON":  true,
+	"LHS":   true,
+	"QPS":   true,
+	"RAM":   true,
+	"RHS":   true,
+	"RPC":   true,
+	"SLA":   true,
+	"SMTP":  true,
+	"SSH":   true,
+	"TLS":   true,
+	"TTL":   true,
+	"UI":    true,
+	"UID":   true,
+	"UUID":  true,
+	"URI":   true,
+	"URL":   true,
+	"UTF8":  true,
+	"VM":    true,
+	"XML":   true,
+}
+
 var config Config
 
 type Config struct {
@@ -123,7 +160,83 @@ func (id Ident) String() (s string) {
 		s = "_"
 	}
 
+	s = lintName(s)
+
 	return
+}
+
+// lintName returns a different name if it should be different.
+func lintName(name string) (should string) {
+	// Fast path for simple cases: "_" and all lowercase.
+	if name == "_" {
+		return name
+	}
+	allLower := true
+	for _, r := range name {
+		if !unicode.IsLower(r) {
+			allLower = false
+			break
+		}
+	}
+	if allLower {
+		return name
+	}
+
+	// Split camelCase at any lower->upper transition, and split on underscores.
+	// Check each word for common initialisms.
+	runes := []rune(name)
+	w, i := 0, 0 // index of start of word, scan
+	for i+1 <= len(runes) {
+		eow := false // whether we hit the end of a word
+		if i+1 == len(runes) {
+			eow = true
+		} else if runes[i+1] != '_' && unicode.IsLower(runes[i]) && !unicode.IsLower(runes[i+1]) {
+			// lower->non-lower
+			eow = true
+		} else {
+			if config.titleCase {
+				if runes[i+1] == '_' {
+					// underscore; shift the remainder forward over any run of underscores
+					eow = true
+					n := 1
+
+
+					for i+n+1 < len(runes) && runes[i+n+1] == '_' {
+						n++
+					}
+
+					// Leave at most one underscore if the underscore is between two digits
+					if i+n+1 < len(runes) && unicode.IsDigit(runes[i]) && unicode.IsDigit(runes[i+n+1]) {
+						n--
+					}
+
+					copy(runes[i+1:], runes[i+n+1:])
+					runes = runes[:len(runes)-n]
+				}
+			}
+		}
+		i++
+		if !eow {
+			continue
+		}
+
+		// [w,i) is a word.
+		word := string(runes[w:i])
+		if u := strings.ToUpper(word); commonInitialisms[u] {
+			// Keep consistent case, which is lowercase only at the start.
+			if w == 0 && unicode.IsLower(runes[w]) {
+				u = strings.ToLower(u)
+			}
+			// All the common initialisms are ASCII,
+			// so we can replace the bytes exactly.
+			copy(runes[w:], []rune(u))
+		} else if w > 0 && strings.ToLower(word) == word {
+			// already all lowercase, and not the first word, so uppercase the first character.
+			runes[w] = unicode.ToUpper(runes[w])
+		}
+		w = i
+	}
+	return string(runes)
 }
 
 // Returns a field tag for the original field name.

--- a/xmlgen_test.go
+++ b/xmlgen_test.go
@@ -120,6 +120,15 @@ func TestSanitizier(t *testing.T) {
 		{"title_case", "Title_case", false},
 		{"title case", "TitleCase", false},
 
+		{"userid", "Userid", true},
+		{"user-id", "UserID", true},
+		{"user_id", "UserID", true},
+		{"user id", "UserID", true},
+		{"userid", "Userid", false},
+		{"user-id", "User_id", false},
+		{"user_id", "User_id", false},
+		{"user id", "UserID", false},
+
 		{"123", "_", true},
 		{"123.foo", "Foo", true},
 		{".foo123", "Foo123", true},


### PR DESCRIPTION
fixed in golint based on https://github.com/golang/lint/blob/7b7f4364ff76043e6c3610281525fabc0d90f0e4/lint.go#L630-L738  reference.

this support `fooId` -> `fooID`.
